### PR TITLE
Avoid useless removal from Promises queues

### DIFF
--- a/src/main/scala/scalaz/ioqueue/Queue.scala
+++ b/src/main/scala/scalaz/ioqueue/Queue.scala
@@ -75,7 +75,7 @@ class Queue[A] private (capacity: Int, ref: Ref[State[A]]) {
     }
 
     val release: (Boolean, Promise[Nothing, A]) => IO[Nothing, Unit] = {
-      case (_, p) => removeTaker(p)
+      case (_, p) => p.poll.void <> removeTaker(p)
     }
     Promise.bracket[Nothing, State[A], A, Boolean](ref)(acquire)(release)
   }
@@ -217,7 +217,7 @@ class Queue[A] private (capacity: Int, ref: Ref[State[A]]) {
     }
 
     val release: (Boolean, Promise[Nothing, Unit]) => IO[Nothing, Unit] = {
-      case (_, p) => removePutter(p)
+      case (_, p) => p.poll.void <> removePutter(p)
     }
 
     Promise.bracket[Nothing, State[A], Unit, Boolean](ref)(acquire)(release)


### PR DESCRIPTION
Promised are internally created in class Queue to block a take or an
offer that cannot be immediately satisfied. They are added to a
scala.collection's Queue. A bracket ensure removal from the queue,
however, the promise is never in the queue when it is completed,
so the O(n) removal is necessary only when the promise was interrupted.
We check that this is the case before removing.

This was pull request scalaz/scalaz-zio#236