### PR TITLE
Test to show offers can still block when queue goes below capacity

### DIFF
--- a/src/test/scala/scalaz/ioqueue/QueueSpec.scala
+++ b/src/test/scala/scalaz/ioqueue/QueueSpec.scala
@@ -132,7 +132,7 @@ class QueueSpec(implicit ee: ExecutionEnv) extends AbstractRTSSpec with AroundTi
     )(e43)}
     make a bounded queue, fill it to capacity then have more offers waiting, each call to `take` should free one waiting offer ${upTo(
       30.second
-    )(e44).pendingUntilFixed("ISSUE 30")}
+    )(e44)}
     """
 
   def e1 = unsafeRun(


### PR DESCRIPTION
This is just a failing, pendingUntilFixed test that shows that blocked offer are not released as soon as they should, that is when there values in the Surplus state are less than capacity. Instead, they block until values goes empty. 
